### PR TITLE
Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:16.04
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN apt-get update && apt-get -y install \
+  build-essential \
+  cmake \
+  git \
+  libboost-all-dev \
+  libxerces-c-dev \
+  libxalan-c-dev \
+  libgtest-dev \
+  libpng16-dev \
+  libtiff5-dev \
+  python-pip
+RUN pip install --upgrade pip
+RUN pip install Genshi
+RUN pip install numpy
+RUN pip install libtiff
+
+WORKDIR /git
+RUN git clone --branch='master' https://github.com/ome/ome-cmake-superbuild.git
+RUN git clone --branch='master' https://github.com/ome/ome-common-cpp.git
+RUN git clone --branch='master' https://github.com/ome/ome-files-cpp.git
+RUN git clone --branch='master' https://github.com/ome/ome-model.git
+
+WORKDIR /build
+RUN cmake \
+    -DCMAKE_CXX_STANDARD=11 \
+    -Dgit-dir=/git \
+    -Dbuild-prerequisites=OFF \
+    -Dome-superbuild_BUILD_gtest=ON \
+    -Dbuild-packages=ome-files \
+    /git/ome-cmake-superbuild
+RUN make
+RUN make install
+RUN ldconfig
+
+WORKDIR /git
+RUN git clone --branch=master https://github.com/ome/ome-files-py
+
+WORKDIR /git/ome-files-py
+RUN python setup.py install
+
+WORKDIR /git/ome-files-py/test
+RUN python all_tests.py
+
+WORKDIR /
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Adds a Dockerfile for an Ubuntu-based image.

To test, check that the image builds and works correctly, e.g.:

```
$ cd docker
$ docker build -t ome-files-py .
$ docker run --rm -it ome-files-py
# cd git/ome-files-py/test
# python all_tests.py
# cd ../examples/
# python dump_planes.py ../test/data/multi-channel-4D-series.companion.ome
```

I have built and uploaded the image to `https://hub.docker.com/u/simleo`, so it can also be used via `docker pull simleo/ome-files-py`.