### PR TITLE
Docker: avoid cloning this repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN make
 RUN make install
 RUN ldconfig
 
-WORKDIR /git
-RUN git clone --branch=master https://github.com/ome/ome-files-py
+COPY . /git/ome-files-py
 
 WORKDIR /git/ome-files-py
 RUN python setup.py install


### PR DESCRIPTION
Changes (and moves to the top) the Dockerfile so that there's no need to clone this repo, as suggested in #4.