### PR TITLE
Tests fixes

### DIFF
--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
+import sys
 import os
 import unittest
 
@@ -33,8 +34,9 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 def main():
     suite = unittest.defaultTestLoader.discover(THIS_DIR)
     runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite)
+    return runner.run(suite)
 
 
 if __name__ == "__main__":
-    main()
+    result = main()
+    sys.exit(not result.wasSuccessful())

--- a/test/test_ometiffreader.py
+++ b/test/test_ometiffreader.py
@@ -36,7 +36,7 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 IMG_PATH = os.path.join(THIS_DIR, "data",
                         "multi-channel-4D-series.companion.ome")
 
-# A-priori knowledge from the Java lib (showinf)
+# A-priori knowledge from the C++ implementation (ome-files info)
 SERIES_COUNT = 1
 IMAGE_COUNT = 60
 SIZE_X = 128
@@ -47,7 +47,7 @@ SIZE_C = 3
 BYTES_PER_PIXEL = 2
 PIXEL_TYPE = "u2"  # uint16
 RGB_C_COUNT = 1
-INTERLEAVED = False
+INTERLEAVED = True
 USED_FILES = [
     IMG_PATH,
     os.path.join(THIS_DIR, "data", "plane.ome.tiff"),

--- a/test/test_ometiffreader.py
+++ b/test/test_ometiffreader.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
+import sys
 import os
 import uuid
 import unittest
@@ -174,4 +175,5 @@ def load_tests(loader, tests, pattern):
 if __name__ == '__main__':
     suite = load_tests(unittest.defaultTestLoader, None, None)
     runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite)
+    result = runner.run(suite)
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
* Changes unit test scripts so that they exit with a nonzero return value in case of failures
* Changes tests to take expected results from the C++ implementation (in particular the `is_interleaved` test should pass again after ome/ome-files-cpp#49)