### PR TITLE
Get XML metadata

### DIFF
--- a/src/ometiffreader.cpp
+++ b/src/ometiffreader.cpp
@@ -343,11 +343,11 @@ PyOMETIFFReader_getUsedFiles(PyOMETIFFReader *self, PyObject *args,
 static PyObject *
 PyOMETIFFReader_getOMEXML(PyOMETIFFReader *self) {
   try {
-    ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> meta(
+    auto meta =
       ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(
-        self->reader->getMetadataStore()));
+        self->reader->getMetadataStore());
     if (!meta) {
-      return PyString_FromString("");
+      Py_RETURN_NONE;
     }
     return PyString_FromString(meta->dumpXML().c_str());
   } catch (const std::exception& e) {

--- a/src/ometiffreader.cpp
+++ b/src/ometiffreader.cpp
@@ -341,7 +341,7 @@ PyOMETIFFReader_getUsedFiles(PyOMETIFFReader *self, PyObject *args,
 
 
 static PyObject *
-PyOMETIFFReader_getMetadata(PyOMETIFFReader *self) {
+PyOMETIFFReader_getOMEXML(PyOMETIFFReader *self) {
   try {
     ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> meta(
       ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(
@@ -394,8 +394,8 @@ static PyMethodDef PyOMETIFFReader_methods[] = {
    METH_VARARGS | METH_KEYWORDS,
    "get_used_files(no_pixels=False): get the files used by this dataset. "
    "If no_pixels is False, exclude pixel data files"},
-  {"get_metadata", (PyCFunction)PyOMETIFFReader_getMetadata, METH_NOARGS,
-   "get_metadata(): get OME XML metadata"},
+  {"get_ome_xml", (PyCFunction)PyOMETIFFReader_getOMEXML, METH_NOARGS,
+   "get_ome_xml(): get the OME XML metadata block"},
   {NULL}  /* Sentinel */
 };
 

--- a/src/ometiffreader.cpp
+++ b/src/ometiffreader.cpp
@@ -46,6 +46,14 @@
 static int
 PyOMETIFFReader_init(PyOMETIFFReader *self, PyObject *args, PyObject *kwds) {
   self->reader = ome::compat::make_shared<ome::files::in::OMETIFFReader>();
+  try {
+    ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store(
+      ome::compat::make_shared<ome::xml::meta::OMEXMLMetadata>());
+    self->reader->setMetadataStore(store);
+  } catch (const std::exception& e) {
+    PyErr_SetString(OMEFilesPyError, e.what());
+    return -1;
+  }
   return 0;
 }
 
@@ -333,20 +341,6 @@ PyOMETIFFReader_getUsedFiles(PyOMETIFFReader *self, PyObject *args,
 
 
 static PyObject *
-PyOMETIFFReader_initMetadata(PyOMETIFFReader *self) {
-  try {
-    ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store(
-      ome::compat::make_shared<ome::xml::meta::OMEXMLMetadata>());
-    self->reader->setMetadataStore(store);
-  } catch (const std::exception& e) {
-    PyErr_SetString(OMEFilesPyError, e.what());
-    return NULL;
-  }
-  Py_RETURN_NONE;
-}
-
-
-static PyObject *
 PyOMETIFFReader_getMetadata(PyOMETIFFReader *self) {
   try {
     ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> meta(
@@ -400,8 +394,6 @@ static PyMethodDef PyOMETIFFReader_methods[] = {
    METH_VARARGS | METH_KEYWORDS,
    "get_used_files(no_pixels=False): get the files used by this dataset. "
    "If no_pixels is False, exclude pixel data files"},
-  {"init_metadata", (PyCFunction)PyOMETIFFReader_initMetadata, METH_NOARGS,
-   "init_metadata(): initialize reader with an OME XML metadata store"},
   {"get_metadata", (PyCFunction)PyOMETIFFReader_getMetadata, METH_NOARGS,
    "get_metadata(): get OME XML metadata"},
   {NULL}  /* Sentinel */

--- a/test/test_ometiffreader.py
+++ b/test/test_ometiffreader.py
@@ -163,6 +163,13 @@ class TestOMETiffReader(unittest.TestCase):
         self.reader.close()
         self.assertRaises(ome_files.Error, self.reader.get_used_files)
 
+    def test_metadata(self):
+        self.assertEqual(self.reader.get_metadata(), "")
+        self.reader.init_metadata()
+        self.reader.set_id(IMG_PATH)
+        self.assertTrue(self.reader.get_metadata().strip().startswith("<?xml"))
+        self.reader.close()
+
 
 def load_tests(loader, tests, pattern):
     test_cases = (TestOMETiffReader,)

--- a/test/test_ometiffreader.py
+++ b/test/test_ometiffreader.py
@@ -164,8 +164,6 @@ class TestOMETiffReader(unittest.TestCase):
         self.assertRaises(ome_files.Error, self.reader.get_used_files)
 
     def test_metadata(self):
-        self.assertEqual(self.reader.get_metadata(), "")
-        self.reader.init_metadata()
         self.reader.set_id(IMG_PATH)
         self.assertTrue(self.reader.get_metadata().strip().startswith("<?xml"))
         self.reader.close()

--- a/test/test_ometiffreader.py
+++ b/test/test_ometiffreader.py
@@ -165,7 +165,7 @@ class TestOMETiffReader(unittest.TestCase):
 
     def test_metadata(self):
         self.reader.set_id(IMG_PATH)
-        self.assertTrue(self.reader.get_metadata().strip().startswith("<?xml"))
+        self.assertTrue(self.reader.get_ome_xml().strip().startswith("<?xml"))
         self.reader.close()
 
 


### PR DESCRIPTION
Adds two methods for:
 * Initialising the reader with an OME XML metadata store;
 * Getting the metadata as XML.