### PR TITLE
Dockerfile: inherit from the C++ one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,8 @@
-FROM ubuntu:16.04
+FROM openmicroscopy/ome-files-cpp-u1604
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-RUN apt-get update && apt-get -y install \
-  build-essential \
-  cmake \
-  git \
-  libboost-all-dev \
-  libxerces-c-dev \
-  libxalan-c-dev \
-  libgtest-dev \
-  libpng16-dev \
-  libtiff5-dev \
-  python-pip
-RUN pip install --upgrade pip
-RUN pip install Genshi
 RUN pip install numpy
 RUN pip install libtiff
-
-WORKDIR /git
-RUN git clone --branch='master' https://github.com/ome/ome-cmake-superbuild.git
-RUN git clone --branch='master' https://github.com/ome/ome-common-cpp.git
-RUN git clone --branch='master' https://github.com/ome/ome-files-cpp.git
-RUN git clone --branch='master' https://github.com/ome/ome-model.git
-
-WORKDIR /build
-RUN cmake \
-    -DCMAKE_CXX_STANDARD=11 \
-    -Dgit-dir=/git \
-    -Dbuild-prerequisites=OFF \
-    -Dome-superbuild_BUILD_gtest=ON \
-    -Dbuild-packages=ome-files \
-    /git/ome-cmake-superbuild
-RUN make
-RUN make install
-RUN ldconfig
 
 COPY . /git/ome-files-py
 


### PR DESCRIPTION
Changes the Dockerfile to inherit from `openmicroscopy/ome-files-cpp-u1604` (where ome-files-cpp installation has been refactored).