### PR TITLE
Use C++11 memory features

### DIFF
--- a/src/ometiffreader.cpp
+++ b/src/ometiffreader.cpp
@@ -29,10 +29,10 @@
 #include <Python.h>
 
 #include <string>
+#include <memory>
 
 #include <boost/filesystem/path.hpp>
 
-#include <ome/compat/memory.h>
 #include <ome/files/in/OMETIFFReader.h>
 #include <ome/files/PixelProperties.h>
 #include <ome/xml/model/enums/PixelType.h>
@@ -45,10 +45,10 @@
 
 static int
 PyOMETIFFReader_init(PyOMETIFFReader *self, PyObject *args, PyObject *kwds) {
-  self->reader = ome::compat::make_shared<ome::files::in::OMETIFFReader>();
+  self->reader = std::make_shared<ome::files::in::OMETIFFReader>();
   try {
-    ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store(
-      ome::compat::make_shared<ome::xml::meta::OMEXMLMetadata>());
+    std::shared_ptr<ome::xml::meta::MetadataStore> store(
+      std::make_shared<ome::xml::meta::OMEXMLMetadata>());
     self->reader->setMetadataStore(store);
   } catch (const std::exception& e) {
     PyErr_SetString(OMEFilesPyError, e.what());
@@ -344,7 +344,7 @@ static PyObject *
 PyOMETIFFReader_getOMEXML(PyOMETIFFReader *self) {
   try {
     auto meta =
-      ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(
+      std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(
         self->reader->getMetadataStore());
     if (!meta) {
       Py_RETURN_NONE;

--- a/src/ometiffreader.h
+++ b/src/ometiffreader.h
@@ -29,11 +29,12 @@
 #pragma once
 
 #include <Python.h>
+#include <memory>
 #include <ome/files/FormatReader.h>
 
 typedef struct {
     PyObject_HEAD
-    ome::compat::shared_ptr<ome::files::FormatReader> reader;
+    std::shared_ptr<ome::files::FormatReader> reader;
 } PyOMETIFFReader;
 
 extern PyTypeObject PyOMETIFFReaderType;


### PR DESCRIPTION
Now that ome-files-cpp requires C++11, use `<memory>` features from the standard library rather than `ome::compat`.