### PR TITLE
Fix Python 2 unicode problem

### DIFF
--- a/ome_files/metadata.py
+++ b/ome_files/metadata.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
+import sys
 import xml.dom.minidom as minidom
 TEXT_NODE = minidom.Node.TEXT_NODE
 
@@ -112,6 +113,8 @@ class XMLAnnotation(Annotation):
 class OMEXMLMetadata(object):
 
     def __init__(self, xml_string):
+        if sys.version_info < (3,):
+            xml_string = xml_string.encode("utf-8")
         self.doc = minidom.parseString(xml_string)
 
     def get_map_annotations(self):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -24,6 +24,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
 import sys
 import unittest
 
@@ -107,6 +111,15 @@ class TestOMEXMLMetadata(unittest.TestCase):
         children = ofmd.get_children(ann.Value)
         self.assertEqual(set(_.nodeName for _ in children),
                          set(("This", "Can", "Be")))
+
+    def test_unicode(self):
+        nonascii = "\N{CYRILLIC CAPITAL LETTER O WITH DIAERESIS}"
+        try:
+            meta = ofmd.OMEXMLMetadata(XML.replace("D0", nonascii))
+        except UnicodeEncodeError:
+            self.fail("Cannot construct OMEXMLMetadata from xml string")
+        by_id = self.__by_id(meta.get_map_annotations())
+        self.assertEqual(by_id["0"].Description, nonascii)
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
In Python 2 minidom does not support direct unicode parsing. This PR fixes the problem by adding a conditional encoding to utf-8.

To test, check that Travis stays green with the newly added test.