### PR TITLE
Update Docker image to ome-files 0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-u1604:0.3.2
+FROM openmicroscopy/ome-files-cpp-u1604:0.4.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN apt-get install -y python3-dev python3-pip


### PR DESCRIPTION
Changes the Dockerfile to inherit from [openmicroscopy/ome-files-cpp-u1604](https://hub.docker.com/r/openmicroscopy/ome-files-cpp-u1604/) version 0.4.0.

**Testing:**

Check that the new Docker image builds correctly (it runs unit tests and examples as part of the process). Can wait for the next automated build at https://hub.docker.com/r/snoopycrimecop/ome-files-py/builds/, although Travis is also configured to build the image, so just checking that Travis is green should suffice. 