### PR TITLE
Docker/Travis: decouple build from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 
-matrix:
-  include:
-  - python: "2.7"
-    env: PLATFORM=u1604
-  - python: "3.3"
-    env: PLATFORM=c7
+python:
+ - "2.7"
+ - "3.6"
+
+env:
+ - PLATFORM=c7
+ - PLATFORM=u1604
 
 sudo: required
 
@@ -14,6 +15,11 @@ services:
 
 before_install: pip install flake8
 
+before_script: flake8 -v .
+
 script:
- - flake8 -v .
  - docker build -t ome-files-py -f Dockerfile.${PLATFORM} .
+ - docker run --name omefilespy -dt ome-files-py
+ - DEBUG=true ./.travis/run_checks
+ - docker stop omefilespy
+ - docker rm omefilespy

--- a/.travis/run_checks
+++ b/.travis/run_checks
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+
+export PYTHON="python${TRAVIS_PYTHON_VERSION%.*}"
+docker exec omefilespy bash -c \
+  "cd /git/ome-files-py/test && ${PYTHON} all_tests.py"
+docker exec omefilespy bash -c \
+  "cd /git/ome-files-py/examples && ${PYTHON} dump_planes.py ../test/data/multi-channel-4D-series.companion.ome"

--- a/Dockerfile.c7
+++ b/Dockerfile.c7
@@ -16,19 +16,7 @@ RUN pip3 install git+git://github.com/pearu/pylibtiff
 COPY . /git/ome-files-py
 
 WORKDIR /git/ome-files-py
-RUN python2 setup.py install
-
-WORKDIR /git/ome-files-py/test
-RUN python2 all_tests.py
-RUN python2 ../examples/dump_planes.py data/multi-channel-4D-series.companion.ome
-
-WORKDIR /git/ome-files-py
-RUN git clean -dfx
-RUN python3 setup.py install
-
-WORKDIR /git/ome-files-py/test
-RUN python3 all_tests.py
-RUN python3 ../examples/dump_planes.py data/multi-channel-4D-series.companion.ome
+RUN python2 setup.py install && git clean -dfx && python3 setup.py install
 
 WORKDIR /
 RUN pip2 install --force-reinstall --upgrade pip

--- a/Dockerfile.u1604
+++ b/Dockerfile.u1604
@@ -15,19 +15,7 @@ RUN pip3 install git+git://github.com/pearu/pylibtiff
 COPY . /git/ome-files-py
 
 WORKDIR /git/ome-files-py
-RUN python2 setup.py install
-
-WORKDIR /git/ome-files-py/test
-RUN python2 all_tests.py
-RUN python2 ../examples/dump_planes.py data/multi-channel-4D-series.companion.ome
-
-WORKDIR /git/ome-files-py
-RUN git clean -dfx
-RUN python3 setup.py install
-
-WORKDIR /git/ome-files-py/test
-RUN python3 all_tests.py
-RUN python3 ../examples/dump_planes.py data/multi-channel-4D-series.companion.ome
+RUN python2 setup.py install && git clean -dfx && python3 setup.py install
 
 WORKDIR /
 RUN pip2 install --force-reinstall --upgrade pip


### PR DESCRIPTION
Moves test running from Docker to Travis. This allows to have a proper build matrix where only python{2,3} stuff is checked for when Travis sets the python version to {2,3}.

To test, check that:

* Travis runs 4 build jobs (2 platforms x 2 python versions);
* Each job actually runs the appropriate checks (e.g., python2 stuff is checked in the Python: 2.7 jobs);
* All jobs are green.

Ref: https://travis-ci.org/simleo/ome-files-py/builds/291066204