### PR TITLE
Consume OME Files 0.5 base Docker images

### DIFF
--- a/Dockerfile.c7
+++ b/Dockerfile.c7
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-c7
+FROM openmicroscopy/ome-files-cpp-c7:0.5.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN yum install -y python-devel python-pip

--- a/Dockerfile.c7
+++ b/Dockerfile.c7
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-c7:0.5.0
+FROM openmicroscopy/ome-files-cpp-c7:0.5
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN yum install -y python-devel python-pip

--- a/Dockerfile.u1604
+++ b/Dockerfile.u1604
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-u1604:0.4.0
+FROM openmicroscopy/ome-files-cpp-u1604:0.5.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN apt-get install -y python3-dev python3-pip

--- a/Dockerfile.u1604
+++ b/Dockerfile.u1604
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-u1604:0.5.0
+FROM openmicroscopy/ome-files-cpp-u1604:0.5
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN apt-get install -y python3-dev python3-pip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python bindings for https://github.com/ome/ome-files-cpp
 * Build the C++ libraries (`ome-common`, `ome-files`, `ome-xml`) and install them to a `PREFIX`
 * Run `python setup.py build_ext -I${PREFIX}/include -L${PREFIX}/lib -R${PREFIX}/lib` followed by `python setup.py build`
 
-Alternatively, you can use the [ome-files-py Docker image](https://hub.docker.com/r/openmicroscopy/ome-files-py).
+Alternatively, you can use the Docker images ([CentOS 7](https://hub.docker.com/r/openmicroscopy/ome-files-py-c7), [Ubuntu 16.04](https://hub.docker.com/r/openmicroscopy/ome-files-py-u1604)).
 
 ## Examples
 


### PR DESCRIPTION
Following the [OME Files 0.5.0 release](http://www.openmicroscopy.org/2017/12/04/ome-files-0-5-0.html), this PR bumps the base images of for the OME Files Python Dockerfile.